### PR TITLE
Documentation and submodule updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ meteor
 
 The Agora server will start on `http://localhost:3000`
 
+In addition to the routes provided by agora-meteor, agora-meteor-demo adds routing and templating for user accounts using [useraccounts:iron-routing](https://github.com/meteor-useraccounts/iron-routing). You can see how it is configured at [lib/config/useraccounts.js](./lib/config/useraccounts.js). In particular, it adds these routes:
+
+* `/signIn`: A sign-in page.
+* `/signUp`: A sign-up page. Upon user creation, a verification email will be sent to the given email address.
+* `/changePwd`: A page where users can change their password.
+* `/forgotPwd`: A page to request a password reset.
+* `/resetPwd`: A page where a user can reset their password after requesting a password reset.
+* `/verifyEmail`: Upon user creation, a verification email will be sent to the given email address with a link to this page, associated with a unique token.
+
 ## Testing
 
 Currently, there is no test suite. However, it is coming!

--- a/package.json
+++ b/package.json
@@ -4,8 +4,6 @@
   "description": "Agora is a non-linear forum intended to facilitate mass communication.",
   "main": "routes.js",
   "dependencies": {
-    "aldeed:collection2": "^2.0.0",
-    "aldeed:simple-schema": "^1.5.0",
     "babel-runtime": "^6.26.0",
     "bcrypt": "^0.8.7",
     "meteor-deque": "^2.1.0",


### PR DESCRIPTION
This patch includes changes to many files:

- `README.md`: Adds information about the routes inherited from different modules, such as the distinction between which are inherited from agora-meteor and which are inherited from agora-meteor-demo.
- `package.json`: I was getting errors from `meteor npm install` because of the meteor packages in the `package.json`, which were already specified in `.meteor/packages`.
- `packages/agoraforum:core`: Lots has changed on master, so I updated the submodule. This includes the documentation branch detailed [here](https://github.com/Agora-Project/agora-meteor/pull/57)